### PR TITLE
add responsive image, this component is extract from mira-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deneb-ui",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --project Deneb-UI-Demo",

--- a/projects/irohalab/deneb-ui/src/core/dom.ts
+++ b/projects/irohalab/deneb-ui/src/core/dom.ts
@@ -1,0 +1,31 @@
+// select closet parent element
+export function closest(el: any, selector: string) {
+  const matchesSelector = el.matches || el.webkitMatchesSelector || el.mozMatchesSelector || el.msMatchesSelector;
+
+  while (el) {
+    if (matchesSelector.call(el, selector)) {
+      return el;
+    } else {
+      el = el.parentElement;
+    }
+  }
+  return null;
+}
+
+export function getRemPixel(remValue: number): number {
+    return remValue * parseFloat(window.getComputedStyle(document.body).getPropertyValue('font-size').match(/(\d+(?:\.\d+)?)px/)[1]);
+}
+
+/**
+ * get the vw in pixel
+ * @param value
+ */
+export function getVwInPixel(value: number): number {
+    let w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+    return value / 100 * w;
+}
+
+export function getVhInPixel(value: number): number {
+    let h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+    return value / 100 * h;
+}

--- a/projects/irohalab/deneb-ui/src/index.ts
+++ b/projects/irohalab/deneb-ui/src/index.ts
@@ -19,7 +19,8 @@ const UI_MODULES = [
     UIScrollbarModule,
     UIDropdownModule,
     UIToggleModule,
-    UIPopoverModule
+    UIPopoverModule,
+
 ];
 
 @NgModule({
@@ -40,5 +41,6 @@ export * from './scrollbar';
 export * from './dropdown';
 export * from './toggle';
 export * from './popover';
+export * from './responsive-image';
 
 export * from './dark-theme.service';

--- a/projects/irohalab/deneb-ui/src/responsive-image/index.ts
+++ b/projects/irohalab/deneb-ui/src/responsive-image/index.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { UIResponsiveImage } from './responsive-image.directive';
+import { UIResponsiveService } from './responsive.service';
+import { UIResponsiveImageWrapper } from './responsive-image-wrapper';
+
+@NgModule({
+    declarations: [UIResponsiveImage, UIResponsiveImageWrapper],
+    providers: [UIResponsiveService],
+    exports: [UIResponsiveImage, UIResponsiveImageWrapper]
+})
+export class UIResponsiveImageModule {
+
+}
+
+export * from './responsive.service';
+export * from './responsive-image.directive'
+export * from './responsive-image-wrapper';

--- a/projects/irohalab/deneb-ui/src/responsive-image/responsive-image-wrapper.ts
+++ b/projects/irohalab/deneb-ui/src/responsive-image/responsive-image-wrapper.ts
@@ -1,0 +1,169 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ResponsiveDimension, UIResponsiveImage } from './responsive-image.directive';
+
+export interface ResponsiveWrapperSize {
+    /**
+     * can be rem, em, pixel, %, vw, auto
+     */
+    width?: string;
+    /**
+     * can be rem, em, pixel, %, vh, auto
+     */
+    height?: string;
+    /**
+     * A value represents height / width
+     * If ratio is used, width must have value and cannot be auto,
+     * and height will be ignored.
+     */
+    ratio?: number;
+
+    /**
+     * the image original width and height in pixel
+     */
+    originalWidth: number;
+    originalHeight: number;
+}
+
+export const DEFAULT_HIDDEN_OPACITY = 0.01;
+
+@Component({
+    selector: 'ui-responsive-image',
+    template: `<img class="responsive-image"
+                    [originalSrc]="src"
+                    [dimension]="dimension"
+                    [style.width]="imageWidth"
+                    [style.height]="imageHeight" 
+                    [style.position]="imagePosition"
+                    [style.opacity]="imageOpacity"
+                    (imageLoad)="onLoad($event)"
+                    (imageError)="onError($event)">`,
+    styles: [`
+        :host {
+            box-sizing: border-box;
+            position: relative;
+        }
+
+        .responsive-image {
+            display: block;
+            object-fit: cover;
+            transition: opacity 500ms;
+        }
+    `],
+    host: {
+        '[style.display]': 'display',
+        '[style.width]': 'hostWidth',
+        '[style.height]': 'hostHeight',
+        '[style.paddingBottom]': 'hostPaddingBottom',
+        '[style.background]': 'background'
+    }
+})
+export class UIResponsiveImageWrapper {
+
+    dimension: ResponsiveDimension;
+
+    @Input()
+    src: string;
+
+    @Input()
+    display: string = 'block';
+
+    @Input()
+    set size(s: ResponsiveWrapperSize) {
+        let dimen: ResponsiveDimension;
+        if (s.ratio) {
+            this.imageWidth = '100%';
+            this.imageHeight = '100%';
+            this.hostWidth = s.width;
+            this.hostHeight = '0';
+            this.hostPaddingBottom = `${s.ratio * 100}%`;
+            this.imagePosition = 'absolute';
+            let widthInPixel = UIResponsiveImage.getPx(s.width);
+            if (widthInPixel !== 0) {
+                dimen = {
+                    width: `${widthInPixel}px`,
+                    height: `${widthInPixel * s.ratio}px`,
+                    originalWidth: s.originalWidth,
+                    originalHeight: s.originalHeight
+                };
+            } else {
+                if (s.originalHeight / s.originalWidth < s.ratio) {
+                    dimen = {
+                        width: 'auto',
+                        height: '100%',
+                        originalWidth: s.originalWidth,
+                        originalHeight: s.originalHeight
+                    }
+                } else {
+                    dimen = {
+                        width: '100%',
+                        height: 'auto',
+                        originalWidth: s.originalWidth,
+                        originalHeight: s.originalHeight
+                    }
+                }
+            }
+        } else {
+            this.hostWidth = s.width;
+            this.hostHeight = s.height;
+            dimen = {
+                width: 'auto',
+                height: 'auto',
+                originalWidth: s.originalWidth,
+                originalHeight: s.originalHeight
+            };
+            if (s.width === 'auto') {
+                this.imageWidth = 'auto';
+            } else {
+                this.imageWidth = '100%';
+                let widthInPixel = Math.round(UIResponsiveImage.getPx(s.width));
+                if (widthInPixel !== 0) {
+                    dimen.width = `${widthInPixel}px`;
+                } else {
+                    dimen.width = '100%';
+                }
+            }
+
+            if (s.height === 'auto') {
+                this.imageHeight = 'auto';
+            } else {
+                this.imageHeight = '100%';
+                let heightInPixel = Math.round(UIResponsiveImage.getPx(s.height));
+                if (heightInPixel !== 0) {
+                    dimen.height = `${heightInPixel}px`;
+                } else {
+                    dimen.height = '100%';
+                }
+            }
+        }
+        this.dimension = dimen;
+    };
+
+    @Input()
+    background: string = '#cccccc'; // color
+
+    hostWidth: string;
+    hostHeight: string;
+    hostPaddingBottom: string = '0';
+
+    imageWidth: string;
+    imageHeight: string;
+    imagePosition: string = 'static';
+
+    imageOpacity: number = DEFAULT_HIDDEN_OPACITY;
+
+    @Output()
+    imageLoad = new EventEmitter<Event>();
+
+    @Output()
+    imageError = new EventEmitter<Event>();
+
+    onLoad(event: Event) {
+        this.imageOpacity = 1;
+        this.imageLoad.emit(event);
+    }
+
+    onError(event: Event) {
+        this.imageOpacity = DEFAULT_HIDDEN_OPACITY;
+        this.imageError.emit(event);
+    }
+}

--- a/projects/irohalab/deneb-ui/src/responsive-image/responsive-image.directive.ts
+++ b/projects/irohalab/deneb-ui/src/responsive-image/responsive-image.directive.ts
@@ -1,0 +1,190 @@
+import {
+    ChangeDetectorRef, Directive, ElementRef, EventEmitter, HostBinding, HostListener, Input, OnChanges, OnDestroy,
+    OnInit, Output, SimpleChanges
+} from '@angular/core';
+import { ObservableStub, UIResponsiveService } from './responsive.service';
+import { getRemPixel, getVhInPixel, getVwInPixel } from '../core/dom';
+
+export interface ResponsiveDimension {
+    width: string; // px, rem, vw, auto, 100%
+    height: string; // px, rem, vh, auto, 100%
+    originalWidth: number;
+    originalHeight: number;
+}
+/**
+ * This directive will let a normal HTMLImageElement load a resized image from source url according to its current dimension.
+ * It use different approach to decide the dimension depends on `dimension` property.
+ * If `dimension` property is not defined or width and height are both set to auto, it will use IntersectionObserver to measure
+ * the actual dimension when image is visible in viewport.
+ * Otherwise, it will calculate the dimension base on width and height
+ * The src will be set to {originalSrc}?size={width}x{height}
+ * - originalSrc is the source url of the image
+ * - width is calculated or measured width
+ * - height is calculated or measured height
+ */
+@Directive({
+    selector: 'img[originalSrc]'
+})
+export class UIResponsiveImage implements OnInit, OnChanges, OnDestroy {
+    private _src: string;
+    private _respSrc: string;
+
+    private _width: number;
+    private _height: number;
+
+    @Input()
+    set originalSrc(url: string) {
+        this._src = url;
+        this.makeRespSrc(false);
+    }
+
+    @Input()
+    dimension: ResponsiveDimension;
+
+    @HostBinding() get src(): string {
+        if (!this._respSrc) {
+            return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVQI12NgYAAAAAMAASDVlMcAAAAASUVORK5CYII=';
+        }
+        return this._respSrc;
+    }
+
+    @Output()
+    imageLoad = new EventEmitter<Event>();
+
+    @Output()
+    imageError = new EventEmitter<Event>();
+
+    observableStub: ObservableStub;
+
+    constructor(private _element: ElementRef,
+                private _responsiveService: UIResponsiveService,
+                private _changeDetector: ChangeDetectorRef) {
+    }
+
+    @HostListener('load', ['$event'])
+    onLoad(event: Event) {
+        if (this._respSrc) {
+            this.imageLoad.emit(event);
+        }
+    }
+
+    @HostListener('error', ['$event'])
+    onError(event: Event) {
+        if (this._respSrc) {
+            this.imageError.emit(event);
+        }
+    }
+
+    ngOnInit(): void {
+        this.dimensionChange(this.dimension);
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        if ('dimension' in changes && !changes['dimension'].firstChange) {
+            const dimension = changes['dimension'].currentValue as ResponsiveDimension;
+            this.dimensionChange(dimension);
+        }
+    }
+
+    ngOnDestroy(): void {
+        if (this.observableStub) {
+            this._responsiveService.unobserve(this.observableStub);
+        }
+    }
+
+    private dimensionChange(dimension: ResponsiveDimension) {
+        const width = dimension.width;
+        const height = dimension.height;
+        if (!dimension ||
+            width === '100%' || height === '100%') {
+            this.needMeasure();
+            return;
+        }
+        if (width !== 'auto') {
+            this._width = Math.round(UIResponsiveImage.getPx(width));
+        } else {
+            this._width = 0;
+        }
+        if (height !== 'auto') {
+            this._height = Math.round(UIResponsiveImage.getPx(height));
+        } else {
+            this._height = 0;
+        }
+        this.makeRespSrc(false);
+    }
+
+    private needMeasure() {
+        if (this.observableStub) {
+            this._responsiveService.unobserve(this.observableStub);
+        }
+        this.observableStub = {
+            target: this._element.nativeElement,
+            callback: (rect: ClientRect) => {
+                if (!this.dimension || this.dimension.width !== 'auto') {
+                    if (rect.width)
+                    this._width = Math.min(this.dimension.originalWidth, Math.round(rect.width));
+                } else {
+                    this._width = 0;
+                }
+                if (!this.dimension || this.dimension.height !== 'auto') {
+                    this._height = Math.min(this.dimension.originalHeight, Math.round(rect.height));
+                } else {
+                    this._height = 0;
+                }
+                this.makeRespSrc(true);
+            },
+            unobserveOnVisible: true
+        };
+        this._responsiveService.observe(this.observableStub);
+    }
+
+    static getPx(dimen: string): number {
+        let match = dimen.match(/(\d*(?:.\d+)?)(px|rem|em|vw|vh)$/);
+        if (!match) {
+            return 0;
+        }
+        let value = parseInt(match[1]);
+        let unit = match[2];
+        switch (unit) {
+            case 'rem':
+                return getRemPixel(value);
+            case 'vw':
+                return getVwInPixel(value);
+            case 'vh':
+                return getVhInPixel(value);
+            default:
+                return value;
+        }
+    }
+
+    private makeRespSrc(manualChangeDetection: boolean) {
+        if (typeof this._width !== 'undefined' && typeof this._height !== 'undefined' && this._src) {
+            if (/^(?:data:).+/.test(this._src)) {
+                this._respSrc = this._src;
+            } else {
+                let width = this._width;
+                let height = this._height;
+                if (this._width !== 0 && this._height !== 0
+                    && Number.isFinite(this.dimension.originalWidth)
+                    && Number.isFinite(this.dimension.originalHeight)) {
+                    let ratio = this._height / this._width;
+                    let originalRatio = this.dimension.originalHeight / this.dimension.originalWidth;
+                    if (originalRatio > ratio) {
+                        width = this._width;
+                        height = 0;
+                    } else if (originalRatio < ratio) {
+                        width = 0;
+                        height = this._height;
+                    }  else {
+                        width = this._width;
+                        height = this._height;
+                    }
+                }
+                this._respSrc = `${this._src}?size=${width}x${height}`;
+            }
+            if (manualChangeDetection) {
+                this._changeDetector.detectChanges();
+            }
+        }
+    }
+}

--- a/projects/irohalab/deneb-ui/src/responsive-image/responsive.service.ts
+++ b/projects/irohalab/deneb-ui/src/responsive-image/responsive.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+
+export interface ObservableStub {
+    target: Element;
+    callback(rect: ClientRect): void;
+    unobserveOnVisible: boolean;
+}
+
+@Injectable()
+export class UIResponsiveService {
+    private _observer: IntersectionObserver;
+
+    private _observableStubList: ObservableStub[] = [];
+
+    constructor() {
+        this._observer = new IntersectionObserver(this.intersectionCallback.bind(this));
+    }
+
+    intersectionCallback(entries: IntersectionObserverEntry[]) {
+        entries.filter(entry => {
+            return entry['isIntersecting']; // current lib.es6.d.ts not updated.
+        }).forEach((entry: IntersectionObserverEntry) => {
+            let stub = this.getStub(entry.target);
+            if (stub) {
+                stub.callback(entry.boundingClientRect);
+                if (stub.unobserveOnVisible) {
+                    this.unobserve(stub);
+                }
+            }
+        });
+    }
+
+    observe(stub: ObservableStub) {
+        if (this.getStub(stub.target)) {
+            throw new Error('Duplicate ObservableStub on target');
+        }
+        this._observableStubList.push(stub);
+        this._observer.observe(stub.target);
+    }
+
+    unobserve(stub: ObservableStub) {
+        let index = this._observableStubList.findIndex(obStub => obStub == stub);
+        if (index !== -1) {
+            this._observableStubList.splice(index, 1);
+            this._observer.unobserve(stub.target);
+        }
+    }
+
+    private getStub(target: Element) {
+        if (!this._observableStubList) {
+            return null;
+        }
+        return this._observableStubList.find(stub => stub.target === target);
+    }
+}


### PR DESCRIPTION
The responsive-image directive and responsive-image-wrapper component has the following features:
1. only load the image when it enters the viewport, this is achieved by IntersectionObserver
2. maintain width-height ratio for a image.
3. generate resize url for CDN image optimazation.
4. show placeholder with a dormant color